### PR TITLE
Added VScript if current map is missing a DSP soundscape

### DIFF
--- a/VPK/pak01/cfg/loadPatches.cfg
+++ b/VPK/pak01/cfg/loadPatches.cfg
@@ -4,5 +4,6 @@
 sv_cheats 1
 script_reload_code patches/DynamicSounds
 script_reload_code patches/maxplayerCheck
+script_reload_code patches/dsp-fix
 script_reload_code server_stuff/adminPlayerModel
 sv_cheats 0

--- a/VPK/pak01/scripts/vscripts/patches/dsp-fix.lua
+++ b/VPK/pak01/scripts/vscripts/patches/dsp-fix.lua
@@ -1,0 +1,28 @@
+local DEBUG = 0
+
+local function checkDSP()
+    DSP_Soundscape = Entities:FindByClassname(nil, "env_soundscape")
+
+    if DSP_Soundscape == nil then
+        SpawnEntityFromTableAsynchronous("env_soundscape",
+        { 
+            enablesoundevent = true,
+            soundevent = "dust2.outdoors_dsp",
+            soundscape = "",
+            radius = 3000,
+            startdisabled = false,
+            uselocaloffset = false,
+            origin = "0.000000 0.000000 360.000000",
+            angles = "0.000000 0.000000 0.000000",
+            scales = "1.000000 1.000000 1.000000",
+        }, nil, nil)
+        if DEBUG == 1 then
+            print("Map is missing DSP Soundscape. Creating one...")
+            DeepPrintTable(DSP_Soundscape)
+        end
+    else
+        -- Map has soundscape. We are good
+    end
+end
+
+ListenToGameEvent("player_connect_full", checkDSP, nil)


### PR DESCRIPTION
CS2's sound is handled by a lot of soundscapes that are using DSP soundevents. If the map is not having any of those in place, the sound gets really weird and starts echo aka. sound unnatural

This VScript patches this by checking if the map that is getting loaded has a env_soundscape implemented and if not, create one in the map so the sound gets fixed